### PR TITLE
Fix edit button in GitHub on production

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -27,7 +27,7 @@ const posts = import.meta.env.PROD
 const index = posts.findIndex(
   ({ url }) => url === Astro.url.pathname.replace(/\/$/, "" /* for prod */)
 );
-const githubUrl = `https://github.com/hiroppy/site/tree/main/src/pages/${Astro.url.pathname}.mdx`;
+const githubUrl = `https://github.com/hiroppy/site/tree/main/src/pages/${Astro.url.pathname.replace(/(^\/|\/$)/g, "")}.mdx`;
 ---
 
 <Layout title={title} description={description} image={image}>


### PR DESCRIPTION
<img width="1464" alt="スクリーンショット 2022-11-18 21 53 19" src="https://user-images.githubusercontent.com/1401711/202709735-fb2dcd3b-fb64-4f5e-a54b-eaada74baf7f.png">

An edit button's href link seems to be mistaken in production.
[This blog post](https://hiroppy.me/blog/nextjs-chunk-optimization) links to `https://github.com/hiroppy/site/tree/main/src/pages//blog/nextjs-chunk-optimization/.mdx`

I haven't tested it, so sorry if it doesn't work
