### PR TITLE
refactor: simplify language colors to essential languages only

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -11,9 +11,6 @@
   --color-css-dark: #563d7c;
   --color-go: #00add8;
   --color-rust: #ce422b;
-  --color-cpp: #f34b7d;
-  --color-c: #555555;
-  --color-shell: #89e051;
   --color-html: #e34c26;
 
   --font-family-body:

--- a/src/utils/languageColors.ts
+++ b/src/utils/languageColors.ts
@@ -11,34 +11,14 @@ export function getLanguageColorClass(language: string | null) {
       return "bg-javascript";
     case "TypeScript":
       return "bg-typescript";
+    case "HTML":
+      return "bg-html";
     case "CSS":
       return "bg-css dark:bg-css-dark";
-    case "Python":
-      return "bg-python";
     case "Go":
       return "bg-go";
     case "Rust":
       return "bg-rust";
-    case "Java":
-      return "bg-java";
-    case "C++":
-      return "bg-cpp";
-    case "C":
-      return "bg-c";
-    case "PHP":
-      return "bg-php";
-    case "Ruby":
-      return "bg-ruby";
-    case "Swift":
-      return "bg-swift";
-    case "Kotlin":
-      return "bg-kotlin";
-    case "Dart":
-      return "bg-dart";
-    case "Shell":
-      return "bg-shell";
-    case "HTML":
-      return "bg-html";
     default:
       return "bg-gray-400 dark:bg-gray-600"; // Default color for unknown languages
   }


### PR DESCRIPTION
## Summary
- Remove unused language color definitions from CSS variables and TypeScript utility
- Keep only essential languages: JavaScript, TypeScript, HTML, CSS, Go, and Rust
- Clean up both `src/global.css` and `src/utils/languageColors.ts` files

## Test plan
- [ ] Verify language colors still work for supported languages
- [ ] Check that unsupported languages fall back to default gray color
- [ ] Run build to ensure no compilation errors

🤖 Generated with [Claude Code](https://claude.ai/code)