### PR TITLE
fix(lint): ignore generated/ in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ pnpm-lock.yaml
 pnpm-workspace.yaml
 test-results
 tests/**/*.json
+generated


### PR DESCRIPTION
## Summary

- main CI の lint が `generated/ogp.json` の末尾改行不足で fail 中
- `generated/` は自動生成ファイル（OGP収集スクリプトの出力）なので prettier の対象外にする

## Test plan

- [x] ローカルで `pnpm fmt:check` が pass することを確認
- [ ] このPRの CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)