### PR TITLE
[codex] refactor feedle articles api helpers

### DIFF
--- a/src/app/(withHeaderAsfullscreen)/labs/feedle/_utils/articlesApi.test.ts
+++ b/src/app/(withHeaderAsfullscreen)/labs/feedle/_utils/articlesApi.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type Article,
+  type Source,
+  createServiceGroups,
+  filterArticlesByPeriod,
+  getServiceGroups,
+} from "./articlesApi";
+
+vi.mock("next/cache", () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}));
+
+const buildArticle = (id: string, publishedAt?: string): Article => ({
+  id,
+  title: id,
+  published_at: publishedAt,
+  hatena_bookmark_count: 0,
+  harvested_at: "2024-05-01T00:00:00.000Z",
+});
+
+const buildSource = (id: string, kind: Source["kind"], count = 0): Source => ({
+  id,
+  name: id,
+  type: "blog",
+  url: `https://example.com/${id}`,
+  enabled: true,
+  kind,
+  website: `https://example.com/${id}`,
+  tags: [],
+  count,
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("filterArticlesByPeriod", () => {
+  it("filters today's articles using JST day boundaries", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-04-30T15:30:00.000Z"));
+
+    const articles = [
+      buildArticle("before-today", "2024-04-30T14:59:59.999Z"),
+      buildArticle("today-start", "2024-04-30T15:00:00.000Z"),
+      buildArticle("today-middle", "2024-05-01T03:00:00.000Z"),
+      buildArticle("tomorrow-start", "2024-05-01T15:00:00.000Z"),
+      buildArticle("missing-published-at"),
+    ];
+
+    expect(
+      filterArticlesByPeriod(articles, "today").map(({ id }) => id),
+    ).toEqual(["today-start", "today-middle"]);
+  });
+
+  it("filters month articles from the JST day start 30 days ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-04-30T15:30:00.000Z"));
+
+    const articles = [
+      buildArticle("before-window", "2024-03-31T14:59:59.999Z"),
+      buildArticle("window-start", "2024-03-31T15:00:00.000Z"),
+      buildArticle("recent", "2024-04-15T00:00:00.000Z"),
+      buildArticle("missing-published-at"),
+    ];
+
+    expect(
+      filterArticlesByPeriod(articles, "month").map(({ id }) => id),
+    ).toEqual(["window-start", "recent"]);
+  });
+
+  it("returns all articles for the all period", () => {
+    const articles = [
+      buildArticle("published", "2024-05-01T00:00:00.000Z"),
+      buildArticle("missing-published-at"),
+    ];
+
+    expect(filterArticlesByPeriod(articles, "all")).toBe(articles);
+  });
+});
+
+describe("service groups", () => {
+  it("groups sources by service name and totals article counts", () => {
+    expect(
+      createServiceGroups([
+        buildSource("React", "official", 3),
+        buildSource("React", "community", 2),
+        buildSource("Next", "release", 5),
+      ]),
+    ).toEqual({
+      React: {
+        sources: [
+          buildSource("React", "official", 3),
+          buildSource("React", "community", 2),
+        ],
+        articleCount: 5,
+      },
+      Next: {
+        sources: [buildSource("Next", "release", 5)],
+        articleCount: 5,
+      },
+    });
+  });
+
+  it("filters service groups by category before grouping", () => {
+    expect(
+      Object.keys(
+        getServiceGroups("official", [
+          buildSource("React", "official"),
+          buildSource("Next", "release"),
+        ]),
+      ),
+    ).toEqual(["React"]);
+  });
+});

--- a/src/app/(withHeaderAsfullscreen)/labs/feedle/_utils/articlesApi.ts
+++ b/src/app/(withHeaderAsfullscreen)/labs/feedle/_utils/articlesApi.ts
@@ -61,6 +61,35 @@ type SourcesResponse = {
 
 const BASE_API_URL = process.env.FEEDLE_API_URL;
 const API_TOKEN = process.env.FEEDLE_API_TOKEN;
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+type FeedleJsonResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+async function fetchFeedleJson<T>(
+  url: string,
+  failureMessage: string,
+): Promise<FeedleJsonResult<T>> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "x-api-token": API_TOKEN || "",
+      },
+    });
+
+    if (!response.ok) {
+      return { ok: false, error: `${failureMessage}: ${response.statusText}` };
+    }
+
+    const data: T = await response.json();
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: getErrorMessage(error) };
+  }
+}
 
 export async function fetchArticles(
   type: string,
@@ -81,45 +110,27 @@ export async function fetchArticles(
   }
   cacheTag(...tags);
 
-  try {
-    const params = new URLSearchParams();
+  const params = new URLSearchParams();
 
-    params.append("domain", type);
+  params.append("domain", type);
 
-    if (sourceId) {
-      params.append("source", sourceId);
-    }
-
-    if (kind && kind !== "all") {
-      params.append("kind", kind);
-    }
-
-    const url = `${BASE_API_URL}/articles?${params}`;
-
-    const response = await fetch(url, {
-      headers: {
-        "x-api-token": API_TOKEN || "",
-      },
-    });
-
-    if (!response.ok) {
-      return {
-        articles: [],
-        error: `Failed to fetch articles: ${response.statusText}`,
-      };
-    }
-
-    const data: ArticlesResponse = await response.json();
-
-    return { articles: data.articles || [] };
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-    return {
-      articles: [],
-      error: errorMessage,
-    };
+  if (sourceId) {
+    params.append("source", sourceId);
   }
+
+  if (kind && kind !== "all") {
+    params.append("kind", kind);
+  }
+
+  const url = `${BASE_API_URL}/articles?${params}`;
+  const result = await fetchFeedleJson<ArticlesResponse>(
+    url,
+    "Failed to fetch articles",
+  );
+
+  if (!result.ok) return { articles: [], error: result.error };
+
+  return { articles: result.data.articles || [] };
 }
 
 export async function fetchSources(
@@ -130,39 +141,28 @@ export async function fetchSources(
   cacheLife("hours");
   cacheTag("feedle:all", `feedle:sources:${type}`);
 
-  try {
-    const url = `${BASE_API_URL}/sources/${type}`;
+  const url = `${BASE_API_URL}/sources/${type}`;
+  const result = await fetchFeedleJson<SourcesResponse>(
+    url,
+    "Failed to fetch sources",
+  );
 
-    const response = await fetch(url, {
-      headers: {
-        "x-api-token": API_TOKEN || "",
-      },
-    });
-
-    if (!response.ok) {
-      return {
-        sources: [],
-        error: `Failed to fetch sources: ${response.statusText}`,
-      };
-    }
-
-    const data: SourcesResponse = await response.json();
-    const lastHarvested = data.summary?.last_harvest_execution
-      ? new Date(data.summary.last_harvest_execution)
-      : undefined;
-
-    return {
-      sources: data.sources || [],
-      lastHarvested,
-    };
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
+  if (!result.ok) {
     return {
       sources: [],
-      error: errorMessage,
+      error: result.error,
     };
   }
+
+  const data = result.data;
+  const lastHarvested = data.summary?.last_harvest_execution
+    ? new Date(data.summary.last_harvest_execution)
+    : undefined;
+
+  return {
+    sources: data.sources || [],
+    lastHarvested,
+  };
 }
 
 export function createServiceGroups(
@@ -207,42 +207,16 @@ export function getServiceGroups(
   return createServiceGroups(categorySource);
 }
 
-// TODO: 下とまとめる
 /**
- * UTC日付をJST午前0時（0:00 JST）に変換し、UTC日付として返す
+ * UTC日付を指定日からN日オフセットしたJST午前0時（0:00 JST）に変換し、UTC日付として返す
  * @param date - 変換する日付
- * @returns 指定日のJST午前0時を表すUTC日付
- */
-function getJSTDayStart(date: Date): Date {
-  const jstOffset = 9 * 60 * 60 * 1000; // UTC+9
-  const dateJST = new Date(date.getTime() + jstOffset);
-
-  const dayStartJST = new Date(
-    Date.UTC(
-      dateJST.getUTCFullYear(),
-      dateJST.getUTCMonth(),
-      dateJST.getUTCDate(),
-      0,
-      0,
-      0,
-      0,
-    ),
-  );
-
-  return new Date(dayStartJST.getTime() - jstOffset);
-}
-
-/**
- * 指定日からN日オフセットした日のJST午前0時を取得
- * @param date - 基準日
  * @param daysOffset - オフセット日数（正=未来、負=過去）
  * @returns オフセット後の日のJST午前0時を表すUTC日付
  */
-function getJSTDayStartOffset(date: Date, daysOffset: number): Date {
-  const jstOffset = 9 * 60 * 60 * 1000; // UTC+9
-  const dateJST = new Date(date.getTime() + jstOffset);
+function getJSTDayStart(date: Date, daysOffset = 0): Date {
+  const dateJST = new Date(date.getTime() + JST_OFFSET_MS);
 
-  const offsetDayStartJST = new Date(
+  const dayStartJST = new Date(
     Date.UTC(
       dateJST.getUTCFullYear(),
       dateJST.getUTCMonth(),
@@ -254,7 +228,7 @@ function getJSTDayStartOffset(date: Date, daysOffset: number): Date {
     ),
   );
 
-  return new Date(offsetDayStartJST.getTime() - jstOffset);
+  return new Date(dayStartJST.getTime() - JST_OFFSET_MS);
 }
 
 export function filterArticlesByPeriod(
@@ -267,8 +241,8 @@ export function filterArticlesByPeriod(
 
   const now = new Date();
   const todayStart = getJSTDayStart(now);
-  const tomorrowStart = getJSTDayStartOffset(now, 1);
-  const oneMonthAgoStart = getJSTDayStartOffset(now, -30);
+  const tomorrowStart = getJSTDayStart(now, 1);
+  const oneMonthAgoStart = getJSTDayStart(now, -30);
 
   const filtered = articles.filter((article) => {
     if (!article.published_at) return false;


### PR DESCRIPTION
## Summary
- Centralize Feedle JSON fetch/error handling for articles and sources.
- Collapse duplicated JST day-start helpers into one offset-aware helper.
- Add unit coverage for Feedle period filtering and service grouping.

## Validation
- `pnpm i --frozen-lockfile`
- `pnpm test -- 'src/app/(withHeaderAsfullscreen)/labs/feedle/_utils/articlesApi.test.ts'`
- `pnpm test`
- `pnpm typecheck`
- `pnpm fmt:check`
- `pnpm lint`
- `GITHUB_TOKEN=dummy FEEDLE_API_URL=http://127.0.0.1:9 FEEDLE_API_TOKEN=dummy NEXT_PUBLIC_SITE_URL=http://localhost:3000 pnpm build`

Plain `pnpm build` was not a valid local proof because Feedle env vars were unset and prerender cache filling timed out for `/labs/feedle/ai/official`; the env-specified build completed successfully.