### PR TITLE
[codex] test(mdx): share remark AST helpers

### DIFF
--- a/src/mdx/remark/_testUtils.ts
+++ b/src/mdx/remark/_testUtils.ts
@@ -1,0 +1,89 @@
+import type { RootContent } from "mdast";
+
+export type MdxjsEsm = Extract<RootContent, { type: "mdxjsEsm" }>;
+export type MdxJsxFlowElement = Extract<
+  RootContent,
+  { type: "mdxJsxFlowElement" }
+>;
+export type MdxJsxAttribute = Extract<
+  MdxJsxFlowElement["attributes"][number],
+  { type: "mdxJsxAttribute" }
+>;
+
+export function isMdxEsm(node: RootContent): node is MdxjsEsm {
+  return node.type === "mdxjsEsm";
+}
+
+export function findMdxEsmNodes(children: RootContent[]): MdxjsEsm[] {
+  return children.filter(isMdxEsm);
+}
+
+export function getMdxEsmNode(node: RootContent): MdxjsEsm {
+  if (!isMdxEsm(node)) {
+    throw new Error(`Expected mdxjsEsm node, received ${node.type}`);
+  }
+  return node;
+}
+
+export function isMdxComponent(
+  node: RootContent,
+  name: string,
+): node is MdxJsxFlowElement {
+  return node.type === "mdxJsxFlowElement" && node.name === name;
+}
+
+export function findMdxComponent(
+  children: RootContent[],
+  name: string,
+): MdxJsxFlowElement | undefined {
+  return children.find((child) => isMdxComponent(child, name));
+}
+
+export function getMdxComponent(
+  children: RootContent[],
+  name: string,
+): MdxJsxFlowElement {
+  const component = findMdxComponent(children, name);
+  if (!component) {
+    throw new Error(`Expected MDX component ${name} to exist`);
+  }
+  return component;
+}
+
+export function findMdxComponents(
+  children: RootContent[],
+  name: string,
+): MdxJsxFlowElement[] {
+  return children.filter((child) => isMdxComponent(child, name));
+}
+
+export function hasMdxComponent(
+  children: RootContent[],
+  name: string,
+): boolean {
+  return findMdxComponent(children, name) !== undefined;
+}
+
+export function getAttr(
+  component: MdxJsxFlowElement,
+  name: string,
+): string | null | undefined {
+  const attr = component.attributes.find(
+    (attribute): attribute is MdxJsxAttribute =>
+      attribute.type === "mdxJsxAttribute" && attribute.name === name,
+  );
+
+  const value = attr?.value;
+  return typeof value === "string" || value == null ? value : undefined;
+}
+
+export function getStringAttr(
+  component: MdxJsxFlowElement,
+  name: string,
+): string {
+  const value = getAttr(component, name);
+  if (typeof value !== "string") {
+    throw new Error(`Expected ${component.name}.${name} to be a string`);
+  }
+  return value;
+}

--- a/src/mdx/remark/_testUtils.ts
+++ b/src/mdx/remark/_testUtils.ts
@@ -1,11 +1,8 @@
 import type { RootContent } from "mdast";
 
-export type MdxjsEsm = Extract<RootContent, { type: "mdxjsEsm" }>;
-export type MdxJsxFlowElement = Extract<
-  RootContent,
-  { type: "mdxJsxFlowElement" }
->;
-export type MdxJsxAttribute = Extract<
+type MdxjsEsm = Extract<RootContent, { type: "mdxjsEsm" }>;
+type MdxJsxFlowElement = Extract<RootContent, { type: "mdxJsxFlowElement" }>;
+type MdxJsxAttribute = Extract<
   MdxJsxFlowElement["attributes"][number],
   { type: "mdxJsxAttribute" }
 >;
@@ -25,7 +22,7 @@ export function getMdxEsmNode(node: RootContent): MdxjsEsm {
   return node;
 }
 
-export function isMdxComponent(
+function isMdxComponent(
   node: RootContent,
   name: string,
 ): node is MdxJsxFlowElement {

--- a/src/mdx/remark/_utils.test.ts
+++ b/src/mdx/remark/_utils.test.ts
@@ -1,5 +1,6 @@
 import type { Root, RootContent } from "mdast";
 import { describe, expect, it } from "vitest";
+import { findMdxEsmNodes, getMdxEsmNode } from "./_testUtils";
 import {
   buildEsmImport,
   ensureComponentImport,
@@ -8,31 +9,40 @@ import {
 
 describe("buildEsmImport", () => {
   it("builds an mdxjsEsm node with the expected value string", () => {
-    const node = buildEsmImport("Alert", "../../mdx/components/Alert");
-    expect((node as any).type).toBe("mdxjsEsm");
-    expect((node as any).value).toBe(
+    const node = getMdxEsmNode(
+      buildEsmImport("Alert", "../../mdx/components/Alert"),
+    );
+    expect(node.type).toBe("mdxjsEsm");
+    expect(node.value).toBe(
       'import { Alert } from "../../mdx/components/Alert";',
     );
   });
 
   it("includes a valid estree ImportDeclaration with sourceType module", () => {
-    const node = buildEsmImport("Details", "../../mdx/components/Details");
-    const program = (node as any).data.estree;
+    const node = getMdxEsmNode(
+      buildEsmImport("Details", "../../mdx/components/Details"),
+    );
+    const program = node.data?.estree;
+    expect(program).toBeDefined();
+    if (!program) throw new Error("Expected estree program");
     expect(program.type).toBe("Program");
     expect(program.sourceType).toBe("module");
     expect(program.body).toHaveLength(1);
 
     const decl = program.body[0];
-    expect(decl.type).toBe("ImportDeclaration");
-    expect(decl.source).toEqual({
-      type: "Literal",
-      value: "../../mdx/components/Details",
-    });
-    expect(decl.specifiers).toHaveLength(1);
-    expect(decl.specifiers[0]).toEqual({
-      type: "ImportSpecifier",
-      imported: { type: "Identifier", name: "Details" },
-      local: { type: "Identifier", name: "Details" },
+    expect(decl).toMatchObject({
+      type: "ImportDeclaration",
+      source: {
+        type: "Literal",
+        value: "../../mdx/components/Details",
+      },
+      specifiers: [
+        {
+          type: "ImportSpecifier",
+          imported: { type: "Identifier", name: "Details" },
+          local: { type: "Identifier", name: "Details" },
+        },
+      ],
     });
   });
 });
@@ -103,8 +113,9 @@ describe("ensureComponentImport", () => {
     ensureComponentImport(tree, "Alert", "../../mdx/components/Alert");
 
     expect(tree.children).toHaveLength(2);
-    expect((tree.children[0] as any).type).toBe("mdxjsEsm");
-    expect((tree.children[0] as any).value).toBe(
+    const importNode = getMdxEsmNode(tree.children[0]);
+    expect(importNode.type).toBe("mdxjsEsm");
+    expect(importNode.value).toBe(
       'import { Alert } from "../../mdx/components/Alert";',
     );
   });
@@ -126,9 +137,7 @@ describe("ensureComponentImport", () => {
 
     ensureComponentImport(tree, "Alert", "../../mdx/components/Alert");
 
-    const imports = tree.children.filter(
-      (child) => (child as any).type === "mdxjsEsm",
-    );
+    const imports = findMdxEsmNodes(tree.children);
     expect(imports).toHaveLength(1);
   });
 });

--- a/src/mdx/remark/remarkAlerts.test.ts
+++ b/src/mdx/remark/remarkAlerts.test.ts
@@ -1,13 +1,12 @@
-import type { Root, RootContent } from "mdast";
+import type { Root } from "mdast";
 import { describe, expect, it } from "vitest";
+import { findMdxEsmNodes, getMdxComponent, isMdxEsm } from "./_testUtils";
 import { remarkAlerts } from "./remarkAlerts";
 
 const runPlugin = (tree: Root) => {
   remarkAlerts()(tree);
   return tree;
 };
-
-const isMdxImport = (node: RootContent) => (node as any).type === "mdxjsEsm";
 
 describe("remarkAlerts", () => {
   it("wraps blockquotes with alert markers and injects a single import", () => {
@@ -35,16 +34,13 @@ describe("remarkAlerts", () => {
 
     const result = runPlugin(tree);
 
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
-    expect((mdxImports[0] as any).value).toContain(
+    expect(mdxImports[0].value).toContain(
       'import { Alert } from "../../mdx/components/Alert";',
     );
 
-    const alertNode = result.children.find(
-      (child) => (child as any).name === "Alert",
-    ) as any;
-    expect(alertNode).toBeDefined();
+    const alertNode = getMdxComponent(result.children, "Alert");
     expect(alertNode.attributes).toEqual([
       { type: "mdxJsxAttribute", name: "type", value: "warning" },
     ]);
@@ -83,13 +79,10 @@ describe("remarkAlerts", () => {
     };
 
     const result = runPlugin(tree);
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
 
-    const alertNode = result.children.find(
-      (child) => (child as any).name === "Alert",
-    ) as any;
-    expect(alertNode).toBeDefined();
+    const alertNode = getMdxComponent(result.children, "Alert");
     expect(alertNode.attributes?.[0]?.value).toBe("tip");
   });
 
@@ -112,7 +105,7 @@ describe("remarkAlerts", () => {
     const result = runPlugin(tree);
 
     // No imports added
-    expect(result.children.some(isMdxImport)).toBe(false);
+    expect(result.children.some(isMdxEsm)).toBe(false);
     // Blockquote left intact
     expect(result.children.some((child) => child.type === "blockquote")).toBe(
       true,

--- a/src/mdx/remark/remarkCodeGroups.test.ts
+++ b/src/mdx/remark/remarkCodeGroups.test.ts
@@ -1,16 +1,19 @@
-import type { Root, RootContent } from "mdast";
+import type { Root } from "mdast";
 import { describe, expect, it } from "vitest";
+import {
+  findMdxComponents,
+  findMdxEsmNodes,
+  getAttr,
+  getMdxComponent,
+  hasMdxComponent,
+  isMdxEsm,
+} from "./_testUtils";
 import { remarkCodeGroups } from "./remarkCodeGroups";
 
 const runPlugin = (tree: Root) => {
   remarkCodeGroups()(tree);
   return tree;
 };
-
-const getAttr = (panel: any, name: string) =>
-  panel.attributes.find((attr: any) => attr.name === name)?.value;
-
-const isMdxImport = (node: RootContent) => (node as any).type === "mdxjsEsm";
 
 describe("remarkCodeGroups", () => {
   it("converts code-group fences into CodeGroup with panels and imports", () => {
@@ -42,19 +45,16 @@ describe("remarkCodeGroups", () => {
 
     const result = runPlugin(tree);
 
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
-    expect((mdxImports[0] as any).value).toContain(
+    expect(mdxImports[0].value).toContain(
       'import { CodeGroup } from "../../mdx/components/CodeGroup";',
     );
 
-    const codeGroup = result.children.find(
-      (child) => (child as any).name === "CodeGroup",
-    ) as any;
-    expect(codeGroup).toBeDefined();
+    const codeGroup = getMdxComponent(result.children, "CodeGroup");
     expect(codeGroup.attributes).toEqual([]);
 
-    const panels = codeGroup.children;
+    const panels = findMdxComponents(codeGroup.children, "div");
     expect(panels).toHaveLength(2);
 
     const [pnpmPanel, npmPanel] = panels;
@@ -102,12 +102,9 @@ describe("remarkCodeGroups", () => {
     };
 
     const result = runPlugin(tree);
-    const codeGroup = result.children.find(
-      (child) => (child as any).name === "CodeGroup",
-    ) as any;
-    expect(codeGroup).toBeDefined();
+    const codeGroup = getMdxComponent(result.children, "CodeGroup");
 
-    const [panel] = codeGroup.children;
+    const [panel] = findMdxComponents(codeGroup.children, "div");
     expect(getAttr(panel, "className")).toBe("code-group-panel");
     expect(getAttr(panel, "data-label")).toBe("Tab 1");
     expect(getAttr(panel, "data-icon")).toBe("file-code");
@@ -136,10 +133,8 @@ describe("remarkCodeGroups", () => {
     const result = runPlugin(tree);
 
     // No imports added
-    expect(result.children.some(isMdxImport)).toBe(false);
+    expect(result.children.some(isMdxEsm)).toBe(false);
     // Original paragraphs remain (no CodeGroup injected)
-    expect(
-      result.children.some((child) => (child as any).name === "CodeGroup"),
-    ).toBe(false);
+    expect(hasMdxComponent(result.children, "CodeGroup")).toBe(false);
   });
 });

--- a/src/mdx/remark/remarkDetails.test.ts
+++ b/src/mdx/remark/remarkDetails.test.ts
@@ -1,13 +1,17 @@
-import type { Root, RootContent } from "mdast";
+import type { Root } from "mdast";
 import { describe, expect, it } from "vitest";
+import {
+  findMdxComponents,
+  findMdxEsmNodes,
+  getMdxComponent,
+  isMdxEsm,
+} from "./_testUtils";
 import { remarkDetails } from "./remarkDetails";
 
 const runPlugin = (tree: Root) => {
   remarkDetails()(tree);
   return tree;
 };
-
-const isMdxImport = (node: RootContent) => (node as any).type === "mdxjsEsm";
 
 describe("remarkDetails", () => {
   it("transforms basic details block with default title", () => {
@@ -32,17 +36,14 @@ describe("remarkDetails", () => {
     const result = runPlugin(tree);
 
     // Check import was added
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
-    expect((mdxImports[0] as any).value).toContain(
+    expect(mdxImports[0].value).toContain(
       'import { Details } from "../../mdx/components/Details";',
     );
 
     // Check Details component was created
-    const detailsNode = result.children.find(
-      (child) => (child as any).name === "Details",
-    ) as any;
-    expect(detailsNode).toBeDefined();
+    const detailsNode = getMdxComponent(result.children, "Details");
     expect(detailsNode.attributes).toEqual([]);
     expect(detailsNode.children).toHaveLength(1);
     expect(detailsNode.children[0]).toMatchObject({
@@ -77,10 +78,7 @@ describe("remarkDetails", () => {
 
     const result = runPlugin(tree);
 
-    const detailsNode = result.children.find(
-      (child) => (child as any).name === "Details",
-    ) as any;
-    expect(detailsNode).toBeDefined();
+    const detailsNode = getMdxComponent(result.children, "Details");
     expect(detailsNode.attributes).toEqual([
       {
         type: "mdxJsxAttribute",
@@ -114,12 +112,10 @@ describe("remarkDetails", () => {
     };
 
     const result = runPlugin(tree);
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
 
-    const detailsNode = result.children.find(
-      (child) => (child as any).name === "Details",
-    ) as any;
+    const detailsNode = getMdxComponent(result.children, "Details");
     expect(detailsNode).toBeDefined();
   });
 
@@ -141,7 +137,7 @@ describe("remarkDetails", () => {
     const result = runPlugin(tree);
 
     // No imports added
-    expect(result.children.some(isMdxImport)).toBe(false);
+    expect(result.children.some(isMdxEsm)).toBe(false);
     // Paragraphs left intact
     expect(
       result.children.filter((child) => child.type === "paragraph"),
@@ -182,24 +178,22 @@ describe("remarkDetails", () => {
     const result = runPlugin(tree);
 
     // Single import
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
 
     // Two Details components
-    const detailsNodes = result.children.filter(
-      (child) => (child as any).name === "Details",
-    );
+    const detailsNodes = findMdxComponents(result.children, "Details");
     expect(detailsNodes).toHaveLength(2);
 
     // Check first Details
-    expect((detailsNodes[0] as any).attributes[0]).toMatchObject({
+    expect(detailsNodes[0].attributes[0]).toMatchObject({
       type: "mdxJsxAttribute",
       name: "summary",
       value: "First",
     });
 
     // Check second Details
-    expect((detailsNodes[1] as any).attributes[0]).toMatchObject({
+    expect(detailsNodes[1].attributes[0]).toMatchObject({
       type: "mdxJsxAttribute",
       name: "summary",
       value: "Second",
@@ -223,10 +217,7 @@ describe("remarkDetails", () => {
 
     const result = runPlugin(tree);
 
-    const detailsNode = result.children.find(
-      (child) => (child as any).name === "Details",
-    ) as any;
-    expect(detailsNode).toBeDefined();
+    const detailsNode = getMdxComponent(result.children, "Details");
     expect(detailsNode.children).toHaveLength(0);
   });
 });

--- a/src/mdx/remark/remarkExtractHeadings.test.ts
+++ b/src/mdx/remark/remarkExtractHeadings.test.ts
@@ -1,5 +1,6 @@
-import type { Heading, Root, RootContent, Text } from "mdast";
+import type { Heading, Root, Text } from "mdast";
 import { describe, expect, it } from "vitest";
+import { isMdxEsm } from "./_testUtils";
 import { remarkExtractHeadings } from "./remarkExtractHeadings";
 
 const runPlugin = (tree: Root) => {
@@ -7,10 +8,8 @@ const runPlugin = (tree: Root) => {
   return tree;
 };
 
-const isMdxExport = (node: RootContent) => (node as any).type === "mdxjsEsm";
-
 const getExportValue = (tree: Root): any => {
-  const exportNode = tree.children.find(isMdxExport) as any;
+  const exportNode = tree.children.find(isMdxEsm);
   if (!exportNode) return undefined;
 
   // Extract JSON from "export const headings = [...];"
@@ -47,9 +46,9 @@ describe("remarkExtractHeadings", () => {
 
     const result = runPlugin(tree);
 
-    const exportNode = result.children.find(isMdxExport) as any;
+    const exportNode = result.children.find(isMdxEsm);
     expect(exportNode).toBeDefined();
-    expect(exportNode.value).toContain("export const headings =");
+    expect(exportNode?.value).toContain("export const headings =");
 
     const headings = getExportValue(result);
     expect(headings).toHaveLength(3);
@@ -91,7 +90,7 @@ describe("remarkExtractHeadings", () => {
 
     const result = runPlugin(tree);
 
-    const exportNode = result.children.find(isMdxExport) as any;
+    const exportNode = result.children.find(isMdxEsm);
     expect(exportNode).toBeDefined();
 
     const headings = getExportValue(result);
@@ -298,8 +297,8 @@ describe("remarkExtractHeadings", () => {
     const result = runPlugin(tree);
 
     // Export should be the first child
-    expect((result.children[0] as any).type).toBe("mdxjsEsm");
-    expect((result.children[1] as any).type).toBe("paragraph");
+    expect(result.children[0].type).toBe("mdxjsEsm");
+    expect(result.children[1].type).toBe("paragraph");
   });
 
   it("generates unique slugs for duplicate heading names", () => {

--- a/src/mdx/remark/remarkOgLinks.test.ts
+++ b/src/mdx/remark/remarkOgLinks.test.ts
@@ -1,13 +1,19 @@
-import type { Root, RootContent } from "mdast";
+import type { Root } from "mdast";
 import { describe, expect, it } from "vitest";
+import {
+  findMdxComponent,
+  findMdxComponents,
+  findMdxEsmNodes,
+  getMdxComponent,
+  hasMdxComponent,
+  isMdxEsm,
+} from "./_testUtils";
 import { remarkOgLinks } from "./remarkOgLinks";
 
 const runPlugin = (tree: Root) => {
   remarkOgLinks()(tree);
   return tree;
 };
-
-const isMdxImport = (node: RootContent) => (node as any).type === "mdxjsEsm";
 
 describe("remarkOgLinks", () => {
   it("replaces standalone link paragraphs with OG components and injects the import", () => {
@@ -30,17 +36,14 @@ describe("remarkOgLinks", () => {
 
     const result = runPlugin(tree);
 
-    const ogNode = result.children.find(
-      (child) => (child as any).name === "OG",
-    ) as any;
-    expect(ogNode).toBeDefined();
+    const ogNode = getMdxComponent(result.children, "OG");
     expect(ogNode.attributes).toEqual([
       { type: "mdxJsxAttribute", name: "url", value: "https://example.com" },
     ]);
 
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
-    expect((mdxImports[0] as any).value).toContain(
+    expect(mdxImports[0].value).toContain(
       'import { OG } from "../../mdx/components/OG";',
     );
   });
@@ -67,10 +70,8 @@ describe("remarkOgLinks", () => {
 
     const result = runPlugin(tree);
 
-    expect(result.children.some((child) => (child as any).name === "OG")).toBe(
-      false,
-    );
-    expect(result.children.some(isMdxImport)).toBe(false);
+    expect(hasMdxComponent(result.children, "OG")).toBe(false);
+    expect(result.children.some(isMdxEsm)).toBe(false);
   });
 
   it("does not duplicate imports when one is already present and handles multiple links", () => {
@@ -108,12 +109,10 @@ describe("remarkOgLinks", () => {
 
     const result = runPlugin(tree);
 
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
 
-    const ogNodes = result.children.filter(
-      (child) => (child as any).name === "OG",
-    ) as any[];
+    const ogNodes = findMdxComponents(result.children, "OG");
     expect(ogNodes).toHaveLength(2);
     expect(ogNodes[0].attributes?.[0]?.value).toBe("https://first.example");
     expect(ogNodes[1].attributes?.[0]?.value).toBe("https://second.example");
@@ -145,17 +144,14 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const youtubeNode = result.children.find(
-        (child) => (child as any).name === "YoutubeCard",
-      ) as any;
-      expect(youtubeNode).toBeDefined();
+      const youtubeNode = getMdxComponent(result.children, "YoutubeCard");
       expect(youtubeNode.attributes).toEqual([
         { type: "mdxJsxAttribute", name: "id", value: "dQw4w9WgXcQ" },
       ]);
 
-      const mdxImports = result.children.filter(isMdxImport);
+      const mdxImports = findMdxEsmNodes(result.children);
       expect(mdxImports).toHaveLength(1);
-      expect((mdxImports[0] as any).value).toContain(
+      expect(mdxImports[0].value).toContain(
         'import { YoutubeCard } from "../../mdx/components/YoutubeCard";',
       );
     });
@@ -182,10 +178,7 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const youtubeNode = result.children.find(
-        (child) => (child as any).name === "YoutubeCard",
-      ) as any;
-      expect(youtubeNode).toBeDefined();
+      const youtubeNode = getMdxComponent(result.children, "YoutubeCard");
       expect(youtubeNode.attributes).toEqual([
         { type: "mdxJsxAttribute", name: "id", value: "dQw4w9WgXcQ" },
       ]);
@@ -216,10 +209,7 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const youtubeNode = result.children.find(
-        (child) => (child as any).name === "YoutubeCard",
-      ) as any;
-      expect(youtubeNode).toBeDefined();
+      const youtubeNode = getMdxComponent(result.children, "YoutubeCard");
       expect(youtubeNode.attributes[0].value).toBe("dQw4w9WgXcQ");
     });
 
@@ -249,10 +239,7 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const youtubeNode = result.children.find(
-        (child) => (child as any).name === "YoutubeCard",
-      ) as any;
-      expect(youtubeNode).toBeDefined();
+      const youtubeNode = getMdxComponent(result.children, "YoutubeCard");
       expect(youtubeNode.attributes[0].value).toBe("dQw4w9WgXcQ");
     });
 
@@ -278,13 +265,9 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const ogNode = result.children.find(
-        (child) => (child as any).name === "OG",
-      ) as any;
+      const ogNode = getMdxComponent(result.children, "OG");
       expect(ogNode).toBeDefined();
-      expect(
-        result.children.find((child) => (child as any).name === "YoutubeCard"),
-      ).toBeUndefined();
+      expect(findMdxComponent(result.children, "YoutubeCard")).toBeUndefined();
     });
   });
 
@@ -311,17 +294,14 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const twitterNode = result.children.find(
-        (child) => (child as any).name === "TwitterCard",
-      ) as any;
-      expect(twitterNode).toBeDefined();
+      const twitterNode = getMdxComponent(result.children, "TwitterCard");
       expect(twitterNode.attributes).toEqual([
         { type: "mdxJsxAttribute", name: "id", value: "20" },
       ]);
 
-      const mdxImports = result.children.filter(isMdxImport);
+      const mdxImports = findMdxEsmNodes(result.children);
       expect(mdxImports).toHaveLength(1);
-      expect((mdxImports[0] as any).value).toContain(
+      expect(mdxImports[0].value).toContain(
         'import { TwitterCard } from "../../mdx/components/TwitterCard";',
       );
     });
@@ -348,10 +328,7 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const twitterNode = result.children.find(
-        (child) => (child as any).name === "TwitterCard",
-      ) as any;
-      expect(twitterNode).toBeDefined();
+      const twitterNode = getMdxComponent(result.children, "TwitterCard");
       expect(twitterNode.attributes[0].value).toBe("20");
     });
 
@@ -380,10 +357,7 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const twitterNode = result.children.find(
-        (child) => (child as any).name === "TwitterCard",
-      ) as any;
-      expect(twitterNode).toBeDefined();
+      const twitterNode = getMdxComponent(result.children, "TwitterCard");
       expect(twitterNode.attributes[0].value).toBe("1234567890");
     });
 
@@ -407,13 +381,9 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const ogNode = result.children.find(
-        (child) => (child as any).name === "OG",
-      ) as any;
+      const ogNode = getMdxComponent(result.children, "OG");
       expect(ogNode).toBeDefined();
-      expect(
-        result.children.find((child) => (child as any).name === "TwitterCard"),
-      ).toBeUndefined();
+      expect(findMdxComponent(result.children, "TwitterCard")).toBeUndefined();
     });
   });
 
@@ -456,7 +426,7 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const mdxImports = result.children.filter(isMdxImport) as any[];
+      const mdxImports = findMdxEsmNodes(result.children);
       expect(mdxImports).toHaveLength(2);
 
       const importValues = mdxImports.map((imp) => imp.value);
@@ -504,17 +474,13 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const youtubeNode = result.children.find(
-        (child) => (child as any).name === "YoutubeCard",
-      );
-      const ogNode = result.children.find(
-        (child) => (child as any).name === "OG",
-      );
+      const youtubeNode = findMdxComponent(result.children, "YoutubeCard");
+      const ogNode = findMdxComponent(result.children, "OG");
 
       expect(youtubeNode).toBeDefined();
       expect(ogNode).toBeDefined();
 
-      const mdxImports = result.children.filter(isMdxImport) as any[];
+      const mdxImports = findMdxEsmNodes(result.children);
       expect(mdxImports).toHaveLength(2);
 
       const importValues = mdxImports.map((imp) => imp.value);
@@ -556,7 +522,7 @@ describe("remarkOgLinks", () => {
 
       const result = runPlugin(tree);
 
-      const mdxImports = result.children.filter(isMdxImport);
+      const mdxImports = findMdxEsmNodes(result.children);
       expect(mdxImports).toHaveLength(1);
     });
   });

--- a/src/mdx/remark/remarkTree.test.ts
+++ b/src/mdx/remark/remarkTree.test.ts
@@ -1,17 +1,17 @@
-import type { Root, RootContent } from "mdast";
+import type { Root } from "mdast";
 import { describe, expect, it } from "vitest";
+import {
+  findMdxComponents,
+  findMdxEsmNodes,
+  getMdxComponent,
+  getStringAttr,
+} from "./_testUtils";
 import { remarkTree } from "./remarkTree";
 
 const runPlugin = (tree: Root) => {
   remarkTree()(tree);
   return tree;
 };
-
-const isMdxImport = (node: RootContent) => (node as any).type === "mdxjsEsm";
-
-const isDirectoryTree = (node: RootContent) =>
-  (node as any).type === "mdxJsxFlowElement" &&
-  (node as any).name === "DirectoryTree";
 
 describe("remarkTree", () => {
   it("replaces tree block with DirectoryTree component and single import", () => {
@@ -74,20 +74,14 @@ describe("remarkTree", () => {
 
     const result = runPlugin(tree);
 
-    const importNodes = result.children.filter(isMdxImport);
+    const importNodes = findMdxEsmNodes(result.children);
     expect(importNodes).toHaveLength(1);
-    expect((importNodes[0] as any).value).toContain(
+    expect(importNodes[0].value).toContain(
       'import { DirectoryTree } from "../../mdx/components/DirectoryTree";',
     );
 
-    const treeComponent = result.children.find(isDirectoryTree) as any;
-    expect(treeComponent).toBeDefined();
-
-    const itemsAttr = treeComponent.attributes.find(
-      (attr: any) => attr.name === "items",
-    );
-    expect(itemsAttr).toBeDefined();
-    const itemsValue = JSON.parse(itemsAttr.value);
+    const treeComponent = getMdxComponent(result.children, "DirectoryTree");
+    const itemsValue = JSON.parse(getStringAttr(treeComponent, "items"));
     expect(itemsValue).toEqual([
       {
         id: "foo-0",
@@ -127,8 +121,8 @@ describe("remarkTree", () => {
 
     const result = runPlugin(tree);
 
-    expect(result.children.filter(isMdxImport)).toHaveLength(0);
-    expect(result.children.filter(isDirectoryTree)).toHaveLength(0);
+    expect(findMdxEsmNodes(result.children)).toHaveLength(0);
+    expect(findMdxComponents(result.children, "DirectoryTree")).toHaveLength(0);
     expect(result.children[0].type).toBe("paragraph");
   });
 
@@ -177,8 +171,8 @@ describe("remarkTree", () => {
 
     const result = runPlugin(tree);
 
-    const importNodes = result.children.filter(isMdxImport);
+    const importNodes = findMdxEsmNodes(result.children);
     expect(importNodes).toHaveLength(1);
-    expect(result.children.filter(isDirectoryTree)).toHaveLength(2);
+    expect(findMdxComponents(result.children, "DirectoryTree")).toHaveLength(2);
   });
 });

--- a/src/mdx/remark/remarkTwoColumn.test.ts
+++ b/src/mdx/remark/remarkTwoColumn.test.ts
@@ -1,16 +1,19 @@
-import type { Root, RootContent } from "mdast";
+import type { Root } from "mdast";
 import { describe, expect, it } from "vitest";
+import {
+  findMdxComponents,
+  findMdxEsmNodes,
+  getAttr,
+  getMdxComponent,
+  hasMdxComponent,
+  isMdxEsm,
+} from "./_testUtils";
 import { remarkTwoColumn } from "./remarkTwoColumn";
 
 const runPlugin = (tree: Root) => {
   remarkTwoColumn()(tree);
   return tree;
 };
-
-const getAttr = (component: any, name: string) =>
-  component.attributes.find((attr: any) => attr.name === name)?.value;
-
-const isMdxImport = (node: RootContent) => (node as any).type === "mdxjsEsm";
 
 describe("remarkTwoColumn", () => {
   it("transforms columns block with defaults (ratio=1:1, gap=md)", () => {
@@ -41,20 +44,17 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
-    expect((mdxImports[0] as any).value).toContain(
+    expect(mdxImports[0].value).toContain(
       'import { TwoColumn } from "../../mdx/components/TwoColumn";',
     );
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    expect(twoColumn).toBeDefined();
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
     expect(getAttr(twoColumn, "ratio")).toBe("1:1");
     expect(getAttr(twoColumn, "gap")).toBe("md");
 
-    const [leftDiv, rightDiv] = twoColumn.children;
+    const [leftDiv, rightDiv] = findMdxComponents(twoColumn.children, "div");
     expect(leftDiv.name).toBe("div");
     expect(rightDiv.name).toBe("div");
     expect(leftDiv.children).toHaveLength(1);
@@ -89,10 +89,7 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    expect(twoColumn).toBeDefined();
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
     expect(getAttr(twoColumn, "ratio")).toBe("2:1");
     expect(getAttr(twoColumn, "gap")).toBe("lg");
   });
@@ -125,9 +122,7 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
     expect(getAttr(twoColumn, "ratio")).toBe("1:2");
     expect(getAttr(twoColumn, "gap")).toBe("md");
   });
@@ -168,10 +163,8 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    const [leftDiv, rightDiv] = twoColumn.children;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
+    const [leftDiv, rightDiv] = findMdxComponents(twoColumn.children, "div");
 
     expect(leftDiv.children).toHaveLength(2);
     expect(rightDiv.children).toHaveLength(2);
@@ -198,10 +191,8 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    const [leftDiv, rightDiv] = twoColumn.children;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
+    const [leftDiv, rightDiv] = findMdxComponents(twoColumn.children, "div");
 
     expect(leftDiv.children).toHaveLength(1);
     expect(rightDiv.children).toHaveLength(0);
@@ -242,10 +233,8 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    const [leftDiv, rightDiv] = twoColumn.children;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
+    const [leftDiv, rightDiv] = findMdxComponents(twoColumn.children, "div");
 
     expect(leftDiv.children).toHaveLength(1);
     // Right column gets everything after first separator
@@ -276,10 +265,8 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    const [leftDiv, rightDiv] = twoColumn.children;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
+    const [leftDiv, rightDiv] = findMdxComponents(twoColumn.children, "div");
 
     expect(leftDiv.children).toHaveLength(0);
     expect(rightDiv.children).toHaveLength(1);
@@ -309,10 +296,8 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    const [leftDiv, rightDiv] = twoColumn.children;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
+    const [leftDiv, rightDiv] = findMdxComponents(twoColumn.children, "div");
 
     expect(leftDiv.children).toHaveLength(1);
     expect(rightDiv.children).toHaveLength(0);
@@ -335,12 +320,9 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    expect(twoColumn).toBeDefined();
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
 
-    const [leftDiv, rightDiv] = twoColumn.children;
+    const [leftDiv, rightDiv] = findMdxComponents(twoColumn.children, "div");
     expect(leftDiv.children).toHaveLength(0);
     expect(rightDiv.children).toHaveLength(0);
   });
@@ -362,10 +344,8 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    expect(result.children.some(isMdxImport)).toBe(false);
-    expect(
-      result.children.some((child) => (child as any).name === "TwoColumn"),
-    ).toBe(false);
+    expect(result.children.some(isMdxEsm)).toBe(false);
+    expect(hasMdxComponent(result.children, "TwoColumn")).toBe(false);
   });
 
   it("falls back to defaults for invalid ratio", () => {
@@ -392,9 +372,7 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
     expect(getAttr(twoColumn, "ratio")).toBe("1:1");
     expect(getAttr(twoColumn, "gap")).toBe("lg");
   });
@@ -423,9 +401,7 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
     expect(getAttr(twoColumn, "ratio")).toBe("2:1");
     expect(getAttr(twoColumn, "gap")).toBe("md");
   });
@@ -459,7 +435,7 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
   });
 
@@ -514,12 +490,10 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumns = result.children.filter(
-      (child) => (child as any).name === "TwoColumn",
-    );
+    const twoColumns = findMdxComponents(result.children, "TwoColumn");
     expect(twoColumns).toHaveLength(2);
 
-    const mdxImports = result.children.filter(isMdxImport);
+    const mdxImports = findMdxEsmNodes(result.children);
     expect(mdxImports).toHaveLength(1);
 
     expect(getAttr(twoColumns[0], "ratio")).toBe("1:1");
@@ -573,10 +547,8 @@ describe("remarkTwoColumn", () => {
 
     const result = runPlugin(tree);
 
-    const twoColumn = result.children.find(
-      (child) => (child as any).name === "TwoColumn",
-    ) as any;
-    const [leftDiv, rightDiv] = twoColumn.children;
+    const twoColumn = getMdxComponent(result.children, "TwoColumn");
+    const [leftDiv, rightDiv] = findMdxComponents(twoColumn.children, "div");
 
     expect(leftDiv.children[0].type).toBe("code");
     expect(rightDiv.children[0].type).toBe("heading");


### PR DESCRIPTION
## Summary

- Add a small shared AST helper for remark tests.
- Replace repeated MDX ESM, MDX component, and JSX attribute lookup code across `src/mdx/remark/*.test.ts`.
- Keep existing test cases and assertions focused on behavior instead of local casts/search predicates.

## Validation

- `pnpm test src/mdx/remark`
- `pnpm exec prettier --check src/mdx/remark/_testUtils.ts src/mdx/remark/*.test.ts`
- `CI=true pnpm lint`

tsc note: `pnpm exec tsc --noEmit --pretty false` still fails on existing project issues around generated Next `PageProps`/`LayoutProps` types and `src/utils/fileIcons.ts` `SiCss`; no helper-specific errors remain.