### PR TITLE
fix: fail build on GitHub auth errors

### DIFF
--- a/src/components/Repositories.tsx
+++ b/src/components/Repositories.tsx
@@ -14,22 +14,34 @@ type Props = {
   }[];
 };
 
+function isGitHubAuthError(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    error.status === 401
+  );
+}
+
 export async function Repositories({ repos }: Props) {
   cacheLife("weeks");
 
-  const repositories = await Promise.allSettled(
-    repos.map(async ({ owner, repo }) => {
-      try {
-        return await getRepositoryInfo(owner, repo);
-      } catch (error) {
-        console.error(`Failed to fetch info for ${owner}/${repo}:`, error);
-        return null;
-      }
-    }),
-  );
-  const res = repositories
-    .map((result) => (result.status === "fulfilled" ? result.value : null))
-    .filter((repo) => repo !== null);
+  const res = (
+    await Promise.all(
+      repos.map(async ({ owner, repo }) => {
+        try {
+          return await getRepositoryInfo(owner, repo);
+        } catch (error) {
+          if (isGitHubAuthError(error)) {
+            throw error;
+          }
+
+          console.error(`Failed to fetch info for ${owner}/${repo}:`, error);
+          return null;
+        }
+      }),
+    )
+  ).filter((repo) => repo !== null);
 
   const formatStars = (count: number) => {
     if (count >= 1000) {


### PR DESCRIPTION
## Summary
- Make repository rendering fail the build when GitHub returns a 401 auth error
- Keep the existing fallback behavior for non-auth repository fetch failures
- Replace `Promise.allSettled` with `Promise.all` so auth failures propagate during prerender/build

## Verification
- `GITHUB_TOKEN=*** pnpm build` fails with `Bad credentials` while prerendering `/about`
- `GITHUB_TOKEN=$(gh auth token) pnpm build` passes
- `pnpm test`
- `pnpm fmt:check`
- `pnpm lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for GitHub repository fetching. Authentication errors are now properly surfaced to users, while non-critical failures are gracefully handled without preventing access to available repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->