### PR TITLE
fix: close contact modal after success

### DIFF
--- a/src/components/ContactButton.tsx
+++ b/src/components/ContactButton.tsx
@@ -3,6 +3,8 @@
 import {
   type FormEvent,
   type FormEventHandler,
+  useCallback,
+  useEffect,
   useId,
   useRef,
   useState,
@@ -25,17 +27,28 @@ type Props = {
 const contactFormSubmitPath = "/form";
 
 export function ContactButton({ variant = "default", className }: Props) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<DialogHandle>(null);
   const dialogId = useId();
   const [status, setStatus] = useState<ContactFormStatus>("idle");
   const [selectedContent, setSelectedContent] = useState("");
   const [canSubmit, setCanSubmit] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<ContactFormFieldErrors>({});
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const closeDialog = useCallback(() => {
+    dialogRef.current?.close();
+  }, []);
+
+  const handleDialogClose = useCallback(() => {
+    setIsDialogOpen(false);
+  }, []);
 
   const openDialog = () => {
     setStatus("idle");
     setFieldErrors({});
     dialogRef.current?.showModal();
+    setIsDialogOpen(true);
   };
 
   const handleFieldChange: FormEventHandler<HTMLFormElement> = (event) => {
@@ -84,9 +97,48 @@ export function ContactButton({ variant = "default", className }: Props) {
     }
   };
 
+  useEffect(() => {
+    if (status !== "success" || !isDialogOpen) return;
+
+    const timeoutId = window.setTimeout(() => {
+      closeDialog();
+    }, 3_000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [closeDialog, isDialogOpen, status]);
+
+  useEffect(() => {
+    if (!isDialogOpen) return;
+
+    const closeIfTriggerHidden = () => {
+      const button = buttonRef.current;
+      if (!button) return;
+
+      const style = window.getComputedStyle(button);
+      const isTriggerHidden =
+        button.getClientRects().length === 0 || style.visibility === "hidden";
+
+      if (isTriggerHidden) {
+        closeDialog();
+      }
+    };
+
+    const handleResize = () => {
+      window.requestAnimationFrame(closeIfTriggerHidden);
+    };
+
+    closeIfTriggerHidden();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [closeDialog, isDialogOpen]);
+
   return (
     <>
       <button
+        ref={buttonRef}
         type="button"
         className={cn(
           "border-line text-text-main inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium no-underline transition-colors hover:bg-gray-100",
@@ -111,6 +163,7 @@ export function ContactButton({ variant = "default", className }: Props) {
         contentClass="p-5 sm:p-6"
         backdrop="blur"
         closeOnBackdrop={false}
+        onClose={handleDialogClose}
       >
         <ContactForm
           idPrefix={dialogId}

--- a/tests/contact-form.test.ts
+++ b/tests/contact-form.test.ts
@@ -45,6 +45,55 @@ test.describe("Contact form", () => {
     );
   });
 
+  test("closes the contact modal 3 seconds after a successful submission", async ({
+    page,
+  }) => {
+    await page.route("**/form", async (route) => {
+      await route.fulfill({
+        status: 200,
+        body: "OK",
+      });
+    });
+
+    await setupPage(page, "http://localhost:3000/");
+
+    const dialog = await openAndFillContactForm(page);
+    await dialog.getByRole("button", { name: "送信" }).click();
+
+    await expect(dialog.getByRole("status")).toContainText(
+      "お問い合わせが送信されました",
+    );
+    await expect(dialog).toBeVisible();
+    await expect(dialog).not.toBeVisible({ timeout: 4_000 });
+    await expect(page.locator("dialog[open]")).toHaveCount(0);
+  });
+
+  test("keeps the mobile menu clickable after resizing with the contact modal open", async ({
+    page,
+  }) => {
+    await setupPage(page, "http://localhost:3000/");
+
+    await page.getByRole("button", { name: "お問い合わせ" }).first().click();
+
+    const dialog = page.getByRole("dialog", { name: "お問い合わせ" });
+    await expect(dialog).toBeVisible();
+
+    await page.setViewportSize({
+      width: 375,
+      height: 667,
+    });
+
+    await expect(page.locator("dialog[open]")).toHaveCount(0);
+
+    const menuButton = page.getByRole("button", { name: "menu" });
+    await menuButton.click();
+
+    await expect(menuButton).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      page.getByRole("navigation", { name: "モバイルナビゲーション" }),
+    ).toBeVisible();
+  });
+
   test("keeps submit disabled without submitting invalid data", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Close the contact modal 3 seconds after the successful submission message is shown.
- Close an open contact modal when its trigger becomes hidden after a responsive resize, preventing an invisible native dialog from blocking the mobile menu.
- Add Playwright coverage for both regressions.

## Root Cause
The contact dialog stayed open after `status` became `success`. When the desktop/sidebar trigger was hidden by a mobile breakpoint, the native dialog could remain open with a zero-sized box and continue blocking page interaction.

## Validation
- `pnpm build`
- `pnpm exec playwright test tests/contact-form.test.ts --project=chrome-routes`
- `pnpm fmt:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`

Linear: HIR-76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact form dialog automatically closes 3 seconds after successful submission
  * Enhanced mobile responsiveness for the contact modal

* **Tests**
  * Added test coverage for form submission and auto-close behavior
  * Added test coverage for mobile menu interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->